### PR TITLE
Add jose and verify Google tokens

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "dotenv": "^16.5.0",
     "drizzle-orm": "^0.44.2",
-    "hono": "^4.7.11"
+    "hono": "^4.7.11",
+    "jose": "^5.2.0"
   },
   "devDependencies": {
     "drizzle-kit": "^0.31.1",

--- a/backend/src/api/auth/google/login.ts
+++ b/backend/src/api/auth/google/login.ts
@@ -1,0 +1,28 @@
+import { Hono } from "hono";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const jwks = createRemoteJWKSet(new URL("https://www.googleapis.com/oauth2/v3/certs"));
+
+const app = new Hono<{ Bindings: { GOOGLE_CLIENT_ID: string } }>();
+
+app.post("/", async (c) => {
+  const idToken = (await c.req.json()).id_token as string | undefined;
+  if (!idToken) {
+    return c.json({ error: "missing id_token" }, 400);
+  }
+  try {
+    const { payload } = await jwtVerify(idToken, jwks, {
+      audience: c.env.GOOGLE_CLIENT_ID,
+      issuer: "https://accounts.google.com",
+    });
+    const userId = payload.sub;
+    if (!userId) {
+      return c.json({ error: "invalid token" }, 400);
+    }
+    return c.json({ sub: userId });
+  } catch (e) {
+    return c.json({ error: "invalid token" }, 400);
+  }
+});
+
+export default app;


### PR DESCRIPTION
## Summary
- add `jose` dependency to backend
- implement Google login route using `jwtVerify` and remote JWKs

## Testing
- `npx biome --version` *(fails: 403 Forbidden)*
- `npm test --prefix backend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d2db411a88321922b2467d26a0d97