### PR TITLE
Add access token middleware

### DIFF
--- a/backend/src/api/auth/jwt.ts
+++ b/backend/src/api/auth/jwt.ts
@@ -1,0 +1,4 @@
+export type JwtPayload = {
+  sub: string;
+  typ?: "refresh";
+};

--- a/backend/src/middleware/index.ts
+++ b/backend/src/middleware/index.ts
@@ -1,0 +1,1 @@
+export * from "./verifyAccessToken";

--- a/backend/src/middleware/verifyAccessToken.ts
+++ b/backend/src/middleware/verifyAccessToken.ts
@@ -1,0 +1,56 @@
+import type { Context, Next } from "hono";
+import { verify } from "hono/jwt";
+import { drizzle } from "drizzle-orm/d1";
+import { eq } from "drizzle-orm";
+import type { Bindings } from "../bindings";
+import { usersTable } from "../db/schema";
+
+/**
+ * Middleware to verify an access token stored in the `token` cookie.
+ *
+ * On success the corresponding user record is attached to the context as
+ * `current_user`.
+ */
+export const verifyAccessToken = async (
+  c: Context<{ Bindings: Bindings }>,
+  next: Next,
+) => {
+  // Extract token from cookie
+  const cookie = c.req.header("Cookie") || "";
+  const match = cookie.match(/(?:^|;\s*)token=([^;]+)/);
+  if (!match) {
+    return c.text("Unauthorized", 401);
+  }
+  const token = match[1];
+
+  // Verify JWT and ensure it's not a refresh token
+  let payload: any;
+  try {
+    payload = await verify(token, c.env.JWT_SECRET);
+  } catch (e) {
+    console.error("JWT verification failed", e);
+    return c.text("Unauthorized", 401);
+  }
+  if (payload.typ === "refresh") {
+    return c.text("Unauthorized", 401);
+  }
+
+  const userId = Number(payload.sub);
+  if (!userId) {
+    return c.text("Unauthorized", 401);
+  }
+
+  // Validate that the user exists
+  const db = drizzle(c.env.DB);
+  const user = await db
+    .select()
+    .from(usersTable)
+    .where(eq(usersTable.id, userId))
+    .get();
+  if (!user) {
+    return c.text("Unauthorized", 401);
+  }
+
+  c.set("current_user", user);
+  await next();
+};

--- a/backend/src/middleware/verifyAccessToken.ts
+++ b/backend/src/middleware/verifyAccessToken.ts
@@ -1,9 +1,6 @@
 import type { Context, Next } from "hono";
 import { verify } from "hono/jwt";
-import { drizzle } from "drizzle-orm/d1";
-import { eq } from "drizzle-orm";
-import type { Bindings } from "../bindings";
-import { usersTable } from "../db/schema";
+import type { JwtPayload } from "../api/auth/jwt";
 
 /**
  * Middleware to verify an access token stored in the `token` cookie.
@@ -11,10 +8,7 @@ import { usersTable } from "../db/schema";
  * On success the corresponding user record is attached to the context as
  * `current_user`.
  */
-export const verifyAccessToken = async (
-  c: Context<{ Bindings: Bindings }>,
-  next: Next,
-) => {
+export const verifyAccessToken = async (c: Context, next: Next) => {
   // Extract token from cookie
   const cookie = c.req.header("Cookie") || "";
   const match = cookie.match(/(?:^|;\s*)token=([^;]+)/);
@@ -24,9 +18,9 @@ export const verifyAccessToken = async (
   const token = match[1];
 
   // Verify JWT and ensure it's not a refresh token
-  let payload: any;
+  let payload: JwtPayload;
   try {
-    payload = await verify(token, c.env.JWT_SECRET);
+    payload = (await verify(token, c.env.JWT_SECRET)) as JwtPayload;
   } catch (e) {
     console.error("JWT verification failed", e);
     return c.text("Unauthorized", 401);
@@ -40,17 +34,6 @@ export const verifyAccessToken = async (
     return c.text("Unauthorized", 401);
   }
 
-  // Validate that the user exists
-  const db = drizzle(c.env.DB);
-  const user = await db
-    .select()
-    .from(usersTable)
-    .where(eq(usersTable.id, userId))
-    .get();
-  if (!user) {
-    return c.text("Unauthorized", 401);
-  }
-
-  c.set("current_user", user);
+  c.set("current_user_id", userId);
   await next();
 };


### PR DESCRIPTION
## Summary
- add middleware to verify JWT from auth cookie
- export middleware index

## Testing
- `npx biome format backend/src/middleware/verifyAccessToken.ts` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684d46cf103c83219fcf0ea7fded92f9